### PR TITLE
Jump back to original window after splitting out a range

### DIFF
--- a/plugin/visual-split.vim
+++ b/plugin/visual-split.vim
@@ -48,6 +48,7 @@ endfunction
 function! s:split(position, line1, line2)
     execute a:position . (a:line2 - a:line1 + 1) . "wincmd s"
     call s:scroll(a:line1)
+    wincmd p
 endfunction
 
 function! s:scroll(line)


### PR DESCRIPTION
As suggested in [/r/vim](https://www.reddit.com/r/vim/comments/3x2fcu/visualsplitvim_plugin_to_control_splits_with/cy10rz4):
After splitting out a range to a new window, put the cursor back to the original window.
