### PR TITLE
6 Don't resize window if there are no vertical splits

### DIFF
--- a/plugin/visual-split.vim
+++ b/plugin/visual-split.vim
@@ -41,6 +41,10 @@ command! -range VSSplitBelow call <SID>split("below", <line1>, <line2>)
 
 " functions execute wincmds
 function! s:resize(line1, line2)
+    if s:single()
+        return
+    endif
+
     execute (a:line2 - a:line1 + 1) . "wincmd _"
     call s:scroll(a:line1)
 endfunction
@@ -57,4 +61,23 @@ function! s:scroll(line)
     call cursor(a:line, 0)
     normal! ztM
     let &scrolloff=scrolloff
+endfunction
+
+function! s:single()
+    " remember original window
+    let winnr = winnr()
+
+    wincmd k " try to move up
+    if winnr() != winnr " found window above
+        wincmd p " move back
+        return 0
+    endif
+
+    wincmd j " try to move down
+    if winnr() != winnr " found window below
+        wincmd p " move back
+        return 0
+    endif
+
+    return 1
 endfunction


### PR DESCRIPTION
Close #6 

Use some wincmds to try to move to split above or below to check if we are in a split. Move back to original split if needed. Abort resizing if there are no splits.
