### PR TITLE
Improve determining resize size when `set wrap` enabled

### DIFF
--- a/plugin/visual-split.vim
+++ b/plugin/visual-split.vim
@@ -59,17 +59,21 @@ function! s:lines_between(line1, line2)
     if &wrap
         " Calculate the number of visibly selected lines, which may be more
         " than the number of actual selected lines.
-        call cursor(a:line1, 0)
-        let l:visual_lines = 0
-        while line('.') <= a:line2
-            normal! gj
-            let l:visual_lines += 1
-        endwhile
-        return l:visual_lines
+        return s:visual_lines_between(a:line1, a:line2)
     else
         " The number of selected lines is a simple calculation.
         return a:line2 - a:line1 + 1
     endif
+endfunction
+
+function! s:visual_lines_between(line1, line2)
+    call cursor(a:line1, 0)
+    let l:visual_lines = 0
+    while line('.') <= a:line2
+        normal! gj
+        let l:visual_lines += 1
+    endwhile
+    return l:visual_lines
 endfunction
 
 function! s:scroll(line)

--- a/plugin/visual-split.vim
+++ b/plugin/visual-split.vim
@@ -45,14 +45,31 @@ function! s:resize(line1, line2)
         return
     endif
 
-    execute (a:line2 - a:line1 + 1) . "wincmd _"
+    execute s:lines_between(a:line1, a:line2) . "wincmd _"
     call s:scroll(a:line1)
 endfunction
 
 function! s:split(position, line1, line2)
-    execute a:position . (a:line2 - a:line1 + 1) . "wincmd s"
+    execute a:position . s:lines_between(a:line1, a:line2) . "wincmd s"
     call s:scroll(a:line1)
     wincmd p
+endfunction
+
+function! s:lines_between(line1, line2)
+    if &wrap
+        " Calculate the number of visibly selected lines, which may be more
+        " than the number of actual selected lines.
+        call cursor(a:line1, 0)
+        let l:visual_lines = 0
+        while line('.') <= a:line2
+            normal! gj
+            let l:visual_lines += 1
+        endwhile
+        return l:visual_lines
+    else
+        " The number of selected lines is a simple calculation.
+        return a:line2 - a:line1 + 1
+    endif
 endfunction
 
 function! s:scroll(line)

--- a/plugin/visual-split.vim
+++ b/plugin/visual-split.vim
@@ -91,6 +91,9 @@ function! s:visual_lines_between(line1, line2)
         let l:previous_col = col('.')
     endwhile
 
+    " Move to back to first row and column of selection.
+    call cursor(a:line1, 1)
+
     return l:visual_lines
 endfunction
 

--- a/plugin/visual-split.vim
+++ b/plugin/visual-split.vim
@@ -68,11 +68,26 @@ endfunction
 
 function! s:visual_lines_between(line1, line2)
     call cursor(a:line1, 0)
+
     let l:visual_lines = 0
+    let l:previous_line = line('.')
+    let l:previous_col = col('.')
+
     while line('.') <= a:line2
         normal! gj
         let l:visual_lines += 1
+
+        if line('.') == l:previous_line && col('.') == l:previous_col
+            " We haven't moved from our previous position, so must be on the
+            " last visual line. We need to break out now since we're never
+            " going to reach a:line2 and would loop indefinitely.
+            break
+        endif
+
+        let l:previous_line = line('.')
+        let l:previous_col = col('.')
     endwhile
+
     return l:visual_lines
 endfunction
 

--- a/plugin/visual-split.vim
+++ b/plugin/visual-split.vim
@@ -73,7 +73,10 @@ function! s:visual_lines_between(line1, line2)
     let l:previous_line = line('.')
     let l:previous_col = col('.')
 
-    while line('.') <= a:line2
+    " Count lines until reach a:line2, or have counted up to lines that can be
+    " displayed in this Vim instance (no point counting beyond this as can't
+    " resize window larger than this, and can seriously harm performance).
+    while line('.') <= a:line2 && l:visual_lines < &lines
         normal! gj
         let l:visual_lines += 1
 


### PR DESCRIPTION
Hi - first off thanks for this plugin, I use it all the time!

Previously, when using the `set wrap` option, the area calculated to resize the window to was the number of actual lines in the visual selection, however the number of visibly selected lines can potentially be more than this if some lines are wrapped.

This commit makes this behaviour more intuitive by calculating the number of visible lines selected when this option is enabled and resizing the window to that size instead, so the resized window should always be the same as the visual selection rather than potentially smaller.

I'm not sure how idiomatic this is as I'm not very familiar with Vimscript, but it seems to do what I wanted. Thanks :)
