### PR TITLE
Prevent previous window being overwritten

### DIFF
--- a/plugin/visual-split.vim
+++ b/plugin/visual-split.vim
@@ -118,20 +118,35 @@ function! s:scroll(line)
 endfunction
 
 function! s:single()
+    " Remember current previous window, as will be overwritten by process of
+    " determining if this is a singular window and we will need to reset it.
+    wincmd p
+    let previous_winnr = winnr()
+    wincmd p
+
     " remember original window
     let winnr = winnr()
 
     wincmd k " try to move up
     if winnr() != winnr " found window above
-        wincmd p " move back
+        wincmd p " Move back to original window.
+        call s:reset_previous_window(previous_winnr)
         return 0
     endif
 
     wincmd j " try to move down
     if winnr() != winnr " found window below
-        wincmd p " move back
+        wincmd p " Move back to original window.
+        call s:reset_previous_window(previous_winnr)
         return 0
     endif
 
     return 1
+endfunction
+
+function! s:reset_previous_window(previous_winnr)
+    " Switch to remembered window and back again to reset previous window to
+    " what it was before we overwrote it.
+    execute a:previous_winnr.'wincmd w'
+    wincmd p
 endfunction


### PR DESCRIPTION
To determine if the current window has any window above or below it we
attempt to move to these windows and then back again. This overwrites
what the original previous window was when the visual-split command was
run, which can cause an unexpected window to be moved to if the user
then runs the `wincmd p` command.

This commit fixes this by remembering what this previous window
originally was and then resetting this if necessary, so the expected
window should then be moved to if `wincmd p` is run.